### PR TITLE
Reduce version constraints on boto3

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,7 @@ pyspark = ">=2.4.0"
 pyspark-stubs = ">=2.4.0"
 
 [packages]
-boto3 = ">=1.9.176"
+boto3 = ">=1.4.4"
 
 [requires]
 python_version = "3.7"


### PR DESCRIPTION
The functionality of boto3 being used here is available since 1.4.4.
Forcing it to be higher than that is making the inclusion difficult
for projects involving older versions of boto3, such as Airflow 1.10.3.